### PR TITLE
fix: add item key

### DIFF
--- a/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
@@ -16,7 +16,7 @@ export const ItemList: React.FC<Prop> = (props) => {
     <div>
       {props.items &&
         props.items.map((item) => {
-          return <Item item={item} />;
+          return <Item item={item} key={item.id} />;
         })}
     </div>
   );

--- a/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
+++ b/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
@@ -135,7 +135,11 @@ export const Listing: React.FC = () => {
             >
               {categories &&
                 categories.map((category) => {
-                  return <option value={category.id}>{category.name}</option>;
+                  return (
+                    <option value={category.id} key={category.id}>
+                      {category.name}
+                    </option>
+                  );
                 })}
             </select>
             <input


### PR DESCRIPTION
↓item画面で下のwarningがでていたので修正しました。
<img width="530" alt="image" src="https://github.com/kotapiku/mercari-build-hackathon-2023/assets/25437132/087b821f-7bf9-4e1d-97c2-e2eff82a1900">

---
変更箇所
- [x] frontend
- [ ] backend