### PR TITLE
`/purchase/:itemID`エンドポイントの編集

### DIFF
--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -479,13 +479,13 @@ func (h *Handler) Purchase(c echo.Context) error {
 	}
 
 	// 売買
-	if err := h.ItemRepo.UpdateItemStatus(ctx, int32(itemID), domain.ItemStatusSoldOut); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
-	}
 	if err := h.UserRepo.UpdateBalance(ctx, userID, user.Balance-item.Price); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	if err := h.UserRepo.UpdateBalance(ctx, sellerID, seller.Balance+item.Price); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err)
+	}
+	if err := h.ItemRepo.UpdateItemStatus(ctx, int32(itemID), domain.ItemStatusSoldOut); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 

--- a/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
@@ -16,7 +16,7 @@ export const ItemList: React.FC<Prop> = (props) => {
     <div>
       {props.items &&
         props.items.map((item) => {
-          return <Item item={item} />;
+          return <Item item={item} key={item.id} />;
         })}
     </div>
   );

--- a/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
+++ b/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
@@ -135,7 +135,11 @@ export const Listing: React.FC = () => {
             >
               {categories &&
                 categories.map((category) => {
-                  return <option value={category.id}>{category.name}</option>;
+                  return (
+                    <option value={category.id} key={category.id}>
+                      {category.name}
+                    </option>
+                  );
                 })}
             </select>
             <input


### PR DESCRIPTION
## What
(すみません、 #3 の差分も入れてしまいました...。#3 を先にマージしてください。次から気をつけます。)
- 所持金が値段より少ないときは購入できないようにしました。
- 自分自身の商品を買えないようにしました。
- 商品がonSaleのときだけ買えるようにしました。
- itemIDはint32なので、それ以上がきたときにオーバーフローを検知できるよう、`strconv.Atoi`ではなく`strconv.ParseInt`を使うように変更しました。

## Why
売買が成立するときだけ購入するため。

## 変更箇所
- [ ] frontend
- [x] backend
