### PR TITLE
fix: unique name problem in adduser/addItem

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -23,14 +23,14 @@ func NewUserRepository(db *sql.DB) UserRepository {
 }
 
 var (
-	ErrExistsSameID = errors.New("already exists same id")
+	ErrConflict = errors.New("id conflict occurs")
 )
 
 func (r *UserDBRepository) AddUser(ctx context.Context, user domain.User) (int64, error) {
 
 	if _, err := r.ExecContext(ctx, "INSERT OR ABORT INTO users (name, password) VALUES (?, ?)", user.Name, user.Password, user.Name); err != nil {
 		if err.Error() == "UNIQUE constraint failed: users.name" {
-			return 0, ErrExistsSameID
+			return 0, ErrConflict
 		}
 		return 0, err
 	}
@@ -74,12 +74,16 @@ func NewItemRepository(db *sql.DB) ItemRepository {
 }
 
 func (r *ItemDBRepository) AddItem(ctx context.Context, item domain.Item) (domain.Item, error) {
-	if _, err := r.ExecContext(ctx, "INSERT INTO items (name, price, description, category_id, seller_id, image, status) VALUES (?, ?, ?, ?, ?, ?, ?)", item.Name, item.Price, item.Description, item.CategoryID, item.UserID, item.Image, item.Status); err != nil {
+	rst, err := r.ExecContext(ctx, "INSERT INTO items (name, price, description, category_id, seller_id, image, status) VALUES (?, ?, ?, ?, ?, ?, ?)", item.Name, item.Price, item.Description, item.CategoryID, item.UserID, item.Image, item.Status)
+	lastID, err2 := rst.LastInsertId()
+	if err != nil {
 		return domain.Item{}, err
 	}
-	// TODO: if other insert query is executed at the same time, it might return wrong id
-	// http.StatusConflict(409) 既に同じIDがあった場合
-	row := r.QueryRowContext(ctx, "SELECT * FROM items WHERE rowid = LAST_INSERT_ROWID()")
+	if err2 != nil {
+		return domain.Item{}, ErrConflict
+	}
+
+	row := r.QueryRowContext(ctx, "SELECT * FROM items WHERE rowid = ?", lastID)
 
 	var res domain.Item
 	return res, row.Scan(&res.ID, &res.Name, &res.Price, &res.Description, &res.CategoryID, &res.UserID, &res.Image, &res.Status, &res.CreatedAt, &res.UpdatedAt)

--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -75,10 +75,10 @@ func NewItemRepository(db *sql.DB) ItemRepository {
 
 func (r *ItemDBRepository) AddItem(ctx context.Context, item domain.Item) (domain.Item, error) {
 	rst, err := r.ExecContext(ctx, "INSERT INTO items (name, price, description, category_id, seller_id, image, status) VALUES (?, ?, ?, ?, ?, ?, ?)", item.Name, item.Price, item.Description, item.CategoryID, item.UserID, item.Image, item.Status)
-	lastID, err2 := rst.LastInsertId()
 	if err != nil {
 		return domain.Item{}, err
 	}
+	lastID, err2 := rst.LastInsertId()
 	if err2 != nil {
 		return domain.Item{}, ErrConflict
 	}

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -151,7 +151,7 @@ func (h *Handler) Register(c echo.Context) error {
 
 	userID, err := h.UserRepo.AddUser(c.Request().Context(), domain.User{Name: req.Name, Password: string(hash)})
 	if err != nil {
-		if err == db.ErrExistsSameID {
+		if err == db.ErrConflict {
 			return echo.NewHTTPError(http.StatusConflict, err)
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -254,6 +254,9 @@ func (h *Handler) AddItem(c echo.Context) error {
 		Status:      domain.ItemStatusInitial,
 	})
 	if err != nil {
+		if err == db.ErrConflict {
+			return echo.NewHTTPError(http.StatusConflict, err)
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/labstack/echo/v4"
 	"github.com/kotapiku/mecari-build-hackathon-2023/backend/db"
 	"github.com/kotapiku/mecari-build-hackathon-2023/backend/domain"
+	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -151,6 +151,9 @@ func (h *Handler) Register(c echo.Context) error {
 
 	userID, err := h.UserRepo.AddUser(c.Request().Context(), domain.User{Name: req.Name, Password: string(hash)})
 	if err != nil {
+		if err == db.ErrExistsSameID {
+			return echo.NewHTTPError(http.StatusConflict, err)
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 

--- a/backend/sql/01_schema.sql
+++ b/backend/sql/01_schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS items
 CREATE TABLE IF NOT EXISTS users
 (
     id       integer primary key autoincrement,
-    name     varchar(50),
+    name     varchar(50) unique,
     password binary(60),
     balance  integer default 0
 );


### PR DESCRIPTION
## What
- tableのuser.nameをuniqueにしました。
- AddUser関数で登録されているユーザー名ではユーザー登録できないようにしました。すでに登録されていた場合409 error codeを返します。
- AddItem関数実行中に別のinsertが走っても適切に追加したもののidが返ってくるように変更しました。

## Why
同じ名前でユーザー登録可能な問題を解決

## 変更箇所
- [ ] frontend
- [x] backend
