### PR TITLE
dbをはやくする(かもしれない)修正

### DIFF
--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -278,7 +278,7 @@ func (h *Handler) AddItem(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
-	item, err := h.ItemRepo.AddItem(c.Request().Context(), domain.Item{
+	itemID, err := h.ItemRepo.AddItem(c.Request().Context(), domain.Item{
 		Name:        req.Name,
 		CategoryID:  req.CategoryID,
 		UserID:      userID,
@@ -294,7 +294,7 @@ func (h *Handler) AddItem(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
-	return c.JSON(http.StatusOK, addItemResponse{ID: int64(item.ID)})
+	return c.JSON(http.StatusOK, addItemResponse{ID: itemID})
 }
 
 func (h *Handler) Sell(c echo.Context) error {

--- a/backend/sql/01_schema.sql
+++ b/backend/sql/01_schema.sql
@@ -1,3 +1,9 @@
+CREATE TABLE IF NOT EXISTS category
+(
+    id   integer primary key,
+    name varchar(50)
+);
+
 CREATE TABLE IF NOT EXISTS items
 (
     id          integer primary key autoincrement,
@@ -9,7 +15,8 @@ CREATE TABLE IF NOT EXISTS items
     image       blob,
     status      integer,
     created_at  text NOT NULL DEFAULT (DATETIME('now', 'localtime')),
-    updated_at  text NOT NULL DEFAULT (DATETIME('now', 'localtime'))
+    updated_at  text NOT NULL DEFAULT (DATETIME('now', 'localtime')),
+    FOREIGN KEY(category_id) REFERENCES category(id)
 );
 
 CREATE TABLE IF NOT EXISTS users
@@ -18,12 +25,6 @@ CREATE TABLE IF NOT EXISTS users
     name     varchar(50) unique,
     password binary(60),
     balance  integer default 0
-);
-
-CREATE TABLE IF NOT EXISTS category
-(
-    id   integer primary key,
-    name varchar(50)
 );
 
 CREATE TABLE IF NOT EXISTS status


### PR DESCRIPTION
## What
- usersテーブルのnameがuniqueなことを利用してAddUserをinsert or abort使うように書き換えました。以前は既に名前が登録されているか確認してからinsertしていましたが、これを同時にできるようになりました。
- AddItemの返り値を、selectを使ってitemを再取得して返していて、id以外は使っていなかったので、再取得をやめてidだけを返すように変更しました。
- itemsテーブルのcategory_idにforeign keyを設定することで、left outer joinを早くしました。

## 変更箇所
- [ ] frontend
- [x] backend
