### PR TITLE
売り切れた商品をHomeに表示＆各UIの変更

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -163,7 +163,7 @@ func (r *ItemDBRepository) GetItems(ctx context.Context, onSaleOnly bool) ([]dom
 	if onSaleOnly {
 		rows, err = r.QueryContext(ctx, selectItemsWithCat+"WHERE status = ? ORDER BY updated_at desc", domain.ItemStatusOnSale)
 	} else {
-		rows, err = r.QueryContext(ctx, selectItemsWithCat+"ORDER BY updated_at desc")
+		rows, err = r.QueryContext(ctx, selectItemsWithCat+"WHERE status = ? OR status = ? ORDER BY updated_at desc", domain.ItemStatusOnSale, domain.ItemStatusSoldOut)
 	}
 	if err != nil {
 		return nil, err

--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -85,7 +85,7 @@ type ItemRepository interface {
 	AddItem(ctx context.Context, item domain.Item) (int64, error)
 	GetItem(ctx context.Context, id int32) (domain.Item, error)
 	GetItemImage(ctx context.Context, id int32) ([]byte, error)
-	GetItems(ctx context.Context, status domain.ItemStatus) ([]domain.ItemWithCategory, error)
+	GetItems(ctx context.Context, onSaleOnly bool) ([]domain.ItemWithCategory, error)
 	GetItemsByUserID(ctx context.Context, userID int64) ([]domain.Item, error)
 	GetCategory(ctx context.Context, id int64) (domain.Category, error)
 	GetCategories(ctx context.Context) ([]domain.Category, error)
@@ -157,8 +157,14 @@ func (r *ItemDBRepository) GetItemImage(ctx context.Context, id int32) ([]byte, 
 	return image, row.Scan(&image)
 }
 
-func (r *ItemDBRepository) GetItems(ctx context.Context, status domain.ItemStatus) ([]domain.ItemWithCategory, error) {
-	rows, err := r.QueryContext(ctx, selectItemsWithCat+"WHERE status = ? ORDER BY updated_at desc", status)
+func (r *ItemDBRepository) GetItems(ctx context.Context, onSaleOnly bool) ([]domain.ItemWithCategory, error) {
+	var rows *sql.Rows
+	var err error
+	if onSaleOnly {
+		rows, err = r.QueryContext(ctx, selectItemsWithCat+"WHERE status = ? ORDER BY updated_at desc", domain.ItemStatusOnSale)
+	} else {
+		rows, err = r.QueryContext(ctx, selectItemsWithCat+"ORDER BY updated_at desc")
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -357,7 +357,7 @@ func (h *Handler) GetOnSaleItems(c echo.Context) error {
 	return h.getItems(c, true)
 }
 
-func (h *Handler) GetItems(c echo.Context) error {
+func (h *Handler) GetOnSaleSoldOutItems(c echo.Context) error {
 	return h.getItems(c, false)
 }
 

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -329,10 +329,10 @@ func (h *Handler) Sell(c echo.Context) error {
 	return c.JSON(http.StatusOK, "successful")
 }
 
-func (h *Handler) getItems(c echo.Context, status domain.ItemStatus) error {
+func (h *Handler) getItems(c echo.Context, onSaleOnly bool) error {
 	ctx := c.Request().Context()
 
-	items, err := h.ItemRepo.GetItems(ctx, status)
+	items, err := h.ItemRepo.GetItems(ctx, onSaleOnly)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, err)
 	}
@@ -354,11 +354,11 @@ func (h *Handler) getItems(c echo.Context, status domain.ItemStatus) error {
 }
 
 func (h *Handler) GetOnSaleItems(c echo.Context) error {
-	return h.getItems(c, domain.ItemStatusOnSale)
+	return h.getItems(c, true)
 }
 
-func (h *Handler) GetSoldOutItems(c echo.Context) error {
-	return h.getItems(c, domain.ItemStatusSoldOut)
+func (h *Handler) GetItems(c echo.Context) error {
+	return h.getItems(c, false)
 }
 
 func (h *Handler) GetItem(c echo.Context) error {

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -38,11 +38,11 @@ type registerResponse struct {
 }
 
 type getUserItemsResponse struct {
-	ID           int32  `json:"id"`
-	Name         string `json:"name"`
-	Price        int64  `json:"price"`
-	CategoryName string `json:"category_name"`
-	Status       int64  `json:"status"`
+	ID           int32             `json:"id"`
+	Name         string            `json:"name"`
+	Price        int64             `json:"price"`
+	CategoryName string            `json:"category_name"`
+	Status       domain.ItemStatus `json:"status"`
 }
 
 type getItemsResponse struct {

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -42,6 +42,7 @@ type getUserItemsResponse struct {
 	Name         string `json:"name"`
 	Price        int64  `json:"price"`
 	CategoryName string `json:"category_name"`
+	Status       int64  `json:"status"`
 }
 
 type getItemsResponse struct {
@@ -411,7 +412,7 @@ func (h *Handler) GetUserItems(c echo.Context) error {
 		}
 		for _, cat := range cats {
 			if cat.ID == item.CategoryID {
-				res = append(res, getUserItemsResponse{ID: item.ID, Name: item.Name, Price: item.Price, CategoryName: cat.Name})
+				res = append(res, getUserItemsResponse{ID: item.ID, Name: item.Name, Price: item.Price, CategoryName: cat.Name, Status: item.Status})
 			}
 		}
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -82,7 +82,7 @@ func run(ctx context.Context) int {
 	e.GET("/log", h.AccessLog)
 
 	e.GET("/items", h.GetOnSaleItems)
-	e.GET("/items_sold", h.GetSoldOutItems)
+	e.GET("/items_all", h.GetItems)
 	e.GET("/items/:itemID", h.GetItem)
 	e.GET("/items/:itemID/image", h.GetImage)
 	e.GET("/items/categories", h.GetCategories)

--- a/backend/main.go
+++ b/backend/main.go
@@ -82,7 +82,7 @@ func run(ctx context.Context) int {
 	e.GET("/log", h.AccessLog)
 
 	e.GET("/items", h.GetOnSaleItems)
-	e.GET("/items_all", h.GetItems)
+	e.GET("/items_all", h.GetOnSaleSoldOutItems)
 	e.GET("/items/:itemID", h.GetItem)
 	e.GET("/items/:itemID/image", h.GetImage)
 	e.GET("/items/categories", h.GetCategories)

--- a/frontend/simple-mercari-web/package-lock.json
+++ b/frontend/simple-mercari-web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "simple-mercari-web",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.4.0",
+        "@fortawesome/free-solid-svg-icons": "^6.4.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
@@ -2188,6 +2191,51 @@
       "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -18764,6 +18812,35 @@
       "version": "8.37.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
       "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A=="
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/frontend/simple-mercari-web/package.json
+++ b/frontend/simple-mercari-web/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.4.0",
+    "@fortawesome/free-solid-svg-icons": "^6.4.0",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/simple-mercari-web/src/App.css
+++ b/frontend/simple-mercari-web/src/App.css
@@ -144,3 +144,15 @@ body {
   align-items: center;
   justify-content: left;
 }
+
+.OnSale {
+  opacity: 1;
+}
+
+.SoldOut {
+  opacity: 0.6;
+}
+
+.SoldOutContent {
+  background-color: gray;
+}

--- a/frontend/simple-mercari-web/src/App.css
+++ b/frontend/simple-mercari-web/src/App.css
@@ -1,3 +1,6 @@
+header {
+  z-index: 1;
+}
 body {
   background-color: white;
 }

--- a/frontend/simple-mercari-web/src/App.css
+++ b/frontend/simple-mercari-web/src/App.css
@@ -22,7 +22,7 @@ body {
   flex: 1 1 0%;
   padding: 16px;
   color: black;
-  width: 300px;
+  width: 100%;
 }
 
 #MerInputLabel {

--- a/frontend/simple-mercari-web/src/App.tsx
+++ b/frontend/simple-mercari-web/src/App.tsx
@@ -6,16 +6,16 @@ import { UserProfile } from "./components/UserProfile";
 import { Listing } from "./components/Listing";
 import "./App.css";
 import { Header } from "./components/Header/Header";
-import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 export const App: React.VFC = () => {
   return (
     <>
-      <ToastContainer position="bottom-center"/>
+      <ToastContainer position="bottom-center" />
 
       <BrowserRouter>
-        <div className="MerComponent">
+        <div>
           <Header></Header>
           <Routes>
             <Route index element={<Home />} />

--- a/frontend/simple-mercari-web/src/App.tsx
+++ b/frontend/simple-mercari-web/src/App.tsx
@@ -16,16 +16,14 @@ export const App: React.VFC = () => {
       <ToastContainer position="bottom-center" />
 
       <BrowserRouter>
-        <div className="MerComponent">
-          <Header></Header>
-          <Routes>
-            <Route index element={<Home />} />
-            <Route path="/item/:id" element={<ItemDetail />} />
-            <Route path="/user/:id" element={<UserProfile />} />
-            <Route path="/sell" element={<Listing />} />
-            <Route path="/search" element={<Search />} />
-          </Routes>
-        </div>
+        <Header></Header>
+        <Routes>
+          <Route index element={<Home />} />
+          <Route path="/item/:id" element={<ItemDetail />} />
+          <Route path="/user/:id" element={<UserProfile />} />
+          <Route path="/sell" element={<Listing />} />
+          <Route path="/search" element={<Search />} />
+        </Routes>
       </BrowserRouter>
     </>
   );

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -32,6 +32,24 @@ export const Header: React.FC = () => {
     return localStorage.getItem("activeTab") || "Home";
   });
 
+  const tab = (
+    <Tabs type="boxed" className="is-centered is-medium">
+      {tabs.map((tab) => {
+        return (
+          <Tabs.Tab
+            active={activeTab === tab.name}
+            onClick={() => handleTabClick(tab.name, tab.to)}
+          >
+            <div className="tabItem">
+              {tab.icon}
+              <span>{tab.name}</span>
+            </div>
+          </Tabs.Tab>
+        );
+      })}
+    </Tabs>
+  );
+
   return (
     <>
       <header>
@@ -45,21 +63,7 @@ export const Header: React.FC = () => {
             Logout
           </Button>
         </div>
-        <Tabs type="boxed" className="is-centered is-medium">
-          {tabs.map((tab) => {
-            return (
-              <Tabs.Tab
-                active={activeTab === tab.name}
-                onClick={() => handleTabClick(tab.name, tab.to)}
-              >
-                <div className="tabItem">
-                  {tab.icon}
-                  <span>{tab.name}</span>
-                </div>
-              </Tabs.Tab>
-            );
-          })}
-        </Tabs>
+        {cookies.token ? tab : <></>};
       </header>
     </>
   );

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -15,8 +15,9 @@ export const Header: React.FC = () => {
 
   const onLogout = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
-    removeCookie("userID");
-    removeCookie("token");
+    // removeCookie("userID");
+    removeCookie("userID", { path: "/" });
+    removeCookie("token", { path: "/" });
   };
 
   const tabs = [

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -63,7 +63,7 @@ export const Header: React.FC = () => {
             Logout
           </Button>
         </div>
-        {cookies.token ? tab : <></>};
+        {cookies.token ? tab : <></>}
       </header>
     </>
   );

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -15,7 +15,6 @@ export const Header: React.FC = () => {
 
   const onLogout = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
-    // removeCookie("userID");
     removeCookie("userID", { path: "/" });
     removeCookie("token", { path: "/" });
   };

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { fetcher } from "../../helper";
 import "react-toastify/dist/ReactToastify.css";
+import { MerComponent } from "../MerComponent";
 
 interface Item {
   id: number;
@@ -71,7 +72,10 @@ export const Home = () => {
     </>
   );
 
-  const itemListPage = <ItemList items={items} items_sold={items_sold} />;
-
+  const itemListPage = (
+    <MerComponent>
+      <ItemList items={items} items_sold={items_sold} />
+    </MerComponent>
+  );
   return <>{cookies.token ? itemListPage : signUpAndSignInPage}</>;
 };

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import { fetcher } from "../../helper";
 import "react-toastify/dist/ReactToastify.css";
 import { MerComponent } from "../MerComponent";
+import { Container } from "react-bulma-components";
 
 interface Item {
   id: number;
@@ -61,15 +62,18 @@ export const Home = () => {
   }, []);
 
   const signUpAndSignInPage = (
-    <>
-      <div>
-        <Signup />
+    <Container className="p-2">
+      <div className="columns is-centered">
+        <div className="column is-4">
+          <Signup />
+        </div>
       </div>
-      or
-      <div>
-        <Login />
+      <div className="columns is-centered">
+        <div className="column is-4">
+          <Login />
+        </div>
       </div>
-    </>
+    </Container>
   );
 
   const itemListPage = (

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -12,6 +12,7 @@ interface Item {
   name: string;
   price: number;
   category_name: string;
+  status: number;
 }
 export const Home = () => {
   const [cookies] = useCookies(["userID", "token"]);

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -13,10 +13,9 @@ import { Item } from "../../common/types";
 export const Home = () => {
   const [cookies] = useCookies(["userID", "token"]);
   const [items, setItems] = useState<Item[]>([]);
-  const [items_sold, setItemsSold] = useState<Item[]>([]);
 
   const fetchItems = () => {
-    fetcher<Item[]>(`/items`, {
+    fetcher<Item[]>(`/items_all`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -32,27 +31,9 @@ export const Home = () => {
         toast.error(err.message);
       });
   };
-  const fetchItemsSold = () => {
-    fetcher<Item[]>(`/items_sold`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-    })
-      .then((data) => {
-        console.log("GET success:", data);
-        setItemsSold(data);
-      })
-      .catch((err) => {
-        console.log(`GET error:`, err);
-        toast.error(err.message);
-      });
-  };
 
   useEffect(() => {
     fetchItems();
-    fetchItemsSold();
   }, []);
 
   const signUpAndSignInPage = (
@@ -72,7 +53,7 @@ export const Home = () => {
 
   const itemListPage = (
     <MerComponent>
-      <ItemList items={items} items_sold={items_sold} />
+      <ItemList items={items} />
     </MerComponent>
   );
   return <>{cookies.token ? itemListPage : signUpAndSignInPage}</>;

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -2,7 +2,6 @@ import { Login } from "../Login";
 import { Signup } from "../Signup";
 import { ItemList } from "../ItemList";
 import { useCookies } from "react-cookie";
-import { MerComponent } from "../MerComponent";
 import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { fetcher } from "../../helper";
@@ -17,6 +16,7 @@ interface Item {
 export const Home = () => {
   const [cookies] = useCookies(["userID", "token"]);
   const [items, setItems] = useState<Item[]>([]);
+  const [items_sold, setItemsSold] = useState<Item[]>([]);
 
   const fetchItems = () => {
     fetcher<Item[]>(`/items`, {
@@ -35,9 +35,27 @@ export const Home = () => {
         toast.error(err.message);
       });
   };
+  const fetchItemsSold = () => {
+    fetcher<Item[]>(`/items_sold`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    })
+      .then((data) => {
+        console.log("GET success:", data);
+        setItemsSold(data);
+      })
+      .catch((err) => {
+        console.log(`GET error:`, err);
+        toast.error(err.message);
+      });
+  };
 
   useEffect(() => {
     fetchItems();
+    fetchItemsSold();
   }, []);
 
   const signUpAndSignInPage = (
@@ -52,16 +70,7 @@ export const Home = () => {
     </>
   );
 
-  const itemListPage = (
-    <MerComponent>
-      <div>
-        <span>
-          <p>Logined User ID: {cookies.userID}</p>
-        </span>
-        <ItemList items={items} />
-      </div>
-    </MerComponent>
-  );
+  const itemListPage = <ItemList items={items} items_sold={items_sold} />;
 
   return <>{cookies.token ? itemListPage : signUpAndSignInPage}</>;
 };

--- a/frontend/simple-mercari-web/src/components/Item/Item.tsx
+++ b/frontend/simple-mercari-web/src/components/Item/Item.tsx
@@ -40,13 +40,13 @@ export const Item: React.FC<{ item: Item }> = ({ item }) => {
 
   return (
     <Columns.Column size={4}>
-      <Card className={item.status == 2 ? "OnSale" : "SoldOut"}>
+      <Card className={item.status == 3 ? "SoldOut" : "OnSale"}>
         <Card.Image
           size="1by1"
           src={itemImage}
           onClick={() => navigate(`/item/${item.id}`)}
         />
-        <Card.Content className={item.status == 2 ? "" : "SoldOutContent"}>
+        <Card.Content className={item.status == 3 ? "SoldOutContent" : ""}>
           <Media>
             <Media.Item>
               <Heading size={4}>{item.name}</Heading>
@@ -56,7 +56,6 @@ export const Item: React.FC<{ item: Item }> = ({ item }) => {
                 <p>
                   <span>
                     <FaHashtag style={{ verticalAlign: -2 }} />
-                    {/* <FaHashtag /> */}
                     {item.category_name}
                   </span>
                   <br />

--- a/frontend/simple-mercari-web/src/components/Item/Item.tsx
+++ b/frontend/simple-mercari-web/src/components/Item/Item.tsx
@@ -11,6 +11,7 @@ interface Item {
   name: string;
   price: number;
   category_name: string;
+  status: number;
 }
 export const Item: React.FC<{ item: Item }> = ({ item }) => {
   const navigate = useNavigate();
@@ -39,13 +40,13 @@ export const Item: React.FC<{ item: Item }> = ({ item }) => {
 
   return (
     <Columns.Column size={4}>
-      <Card>
+      <Card className={item.status == 2 ? "OnSale" : "SoldOut"}>
         <Card.Image
           size="1by1"
           src={itemImage}
           onClick={() => navigate(`/item/${item.id}`)}
         />
-        <Card.Content>
+        <Card.Content className={item.status == 2 ? "" : "SoldOutContent"}>
           <Media>
             <Media.Item>
               <Heading size={4}>{item.name}</Heading>

--- a/frontend/simple-mercari-web/src/components/Item/Item.tsx
+++ b/frontend/simple-mercari-web/src/components/Item/Item.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from "react";
 import { useCookies } from "react-cookie";
 import { useNavigate } from "react-router-dom";
 import { fetcherBlob } from "../../helper";
+import "bulma/css/bulma.min.css";
+import { Card, Media, Heading, Content, Columns } from "react-bulma-components";
+import { FaYenSign, FaHashtag } from "react-icons/fa";
 
 interface Item {
   id: number;
@@ -9,7 +12,6 @@ interface Item {
   price: number;
   category_name: string;
 }
-
 export const Item: React.FC<{ item: Item }> = ({ item }) => {
   const navigate = useNavigate();
   const [itemImage, setItemImage] = useState<string>("");
@@ -36,21 +38,38 @@ export const Item: React.FC<{ item: Item }> = ({ item }) => {
   }, [item]);
 
   return (
-    <div>
-      <h3>{item.name}</h3>
-      <img
-        src={itemImage}
-        alt={item.name}
-        height={480}
-        width={480}
-        onClick={() => navigate(`/item/${item.id}`)}
-      />
-      <p>
-        <span>Category: {item.category_name}</span>
-        <br />
-        <span>Price: {item.price}</span>
-        <br />
-      </p>
-    </div>
+    <Columns.Column size={4}>
+      <Card>
+        <Card.Image
+          size="1by1"
+          src={itemImage}
+          onClick={() => navigate(`/item/${item.id}`)}
+        />
+        <Card.Content>
+          <Media>
+            <Media.Item>
+              <Heading size={4}>{item.name}</Heading>
+            </Media.Item>
+            <Media.Item>
+              <Content>
+                <p>
+                  <span>
+                    <FaHashtag style={{ verticalAlign: -2 }} />
+                    {/* <FaHashtag /> */}
+                    {item.category_name}
+                  </span>
+                  <br />
+                  <span>
+                    <FaYenSign style={{ verticalAlign: -2 }} />
+                    {item.price}
+                  </span>
+                  <br />
+                </p>
+              </Content>
+            </Media.Item>
+          </Media>
+        </Card.Content>
+      </Card>
+    </Columns.Column>
   );
 };

--- a/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
@@ -16,7 +16,7 @@ interface Prop {
 
 export const ItemList: React.FC<Prop> = (props) => {
   return (
-    <Columns className="m-1">
+    <Columns>
       {props.items &&
         props.items.map((item) => {
           return <Item item={item} key={item.id} />;

--- a/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
@@ -15,7 +15,6 @@ interface Item {
 
 interface Prop {
   items: Item[];
-  items_sold: Item[];
 }
 
 export const ItemList: React.FC<Prop> = (props) => {
@@ -23,10 +22,6 @@ export const ItemList: React.FC<Prop> = (props) => {
     <Columns>
       {props.items &&
         props.items.map((item) => {
-          return <ItemCard item={item} key={item.id} />;
-        })}
-      {props.items_sold &&
-        props.items_sold.map((item) => {
           return <ItemCard item={item} key={item.id} />;
         })}
     </Columns>

--- a/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
@@ -6,6 +6,7 @@ interface Item {
   name: string;
   price: number;
   category_name: string;
+  status: number;
 }
 
 interface Prop {

--- a/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Item } from "../Item";
+import { Columns } from "react-bulma-components";
 interface Item {
   id: number;
   name: string;
@@ -9,15 +10,20 @@ interface Item {
 
 interface Prop {
   items: Item[];
+  items_sold: Item[];
 }
 
 export const ItemList: React.FC<Prop> = (props) => {
   return (
-    <div>
+    <Columns className="m-1">
       {props.items &&
         props.items.map((item) => {
           return <Item item={item} key={item.id} />;
         })}
-    </div>
+      {props.items_sold &&
+        props.items_sold.map((item) => {
+          return <Item item={item} key={item.id} />;
+        })}
+    </Columns>
   );
 };

--- a/frontend/simple-mercari-web/src/components/Login/Login.tsx
+++ b/frontend/simple-mercari-web/src/components/Login/Login.tsx
@@ -26,8 +26,8 @@ export const Login = () => {
       .then((user) => {
         toast.success("Signed in!");
         console.log("POST success:", user.id);
-        setCookie("userID", user.id);
-        setCookie("token", user.token);
+        setCookie("userID", user.id, { "path": "/" });
+        setCookie("token", user.token, { "path": "/" });
         navigate("/");
       })
       .catch((err) => {

--- a/frontend/simple-mercari-web/src/components/MerComponent/MerComponent.tsx
+++ b/frontend/simple-mercari-web/src/components/MerComponent/MerComponent.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import { useCookies } from "react-cookie";
 import { NotFound } from "../NotFound";
+import { Container } from "react-bulma-components";
 
 interface Prop {
   condition?: () => boolean;
@@ -17,9 +18,5 @@ export const MerComponent: React.FC<Prop> = (props) => {
   ) {
     return <NotFound />;
   }
-  return (
-    <>
-      {props.children}
-    </>
-  );
+  return <Container className="p-2">{props.children}</Container>;
 };

--- a/frontend/simple-mercari-web/src/components/Search/Search.tsx
+++ b/frontend/simple-mercari-web/src/components/Search/Search.tsx
@@ -4,6 +4,7 @@ import { ItemList } from "../ItemList";
 import { toast } from "react-toastify";
 import { fetcher } from "../../helper";
 import { Item } from "../../common/types";
+import { MerComponent } from "../MerComponent";
 
 export const Search: React.FC = () => {
   const location = useLocation();
@@ -42,6 +43,10 @@ export const Search: React.FC = () => {
   } else if (!searchResult) {
     return <div>No search result.</div>;
   } else {
-    return <ItemList items={searchResult} />;
+    return (
+      <MerComponent>
+        <ItemList items={searchResult} />
+      </MerComponent>
+    );
   }
 };

--- a/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
+++ b/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
@@ -41,6 +41,7 @@ export const Signup = () => {
       <div className="Signup">
         <label id="MerInputLabel">User Name</label>
         <input
+          className="is-fullwidth"
           type="text"
           name="name"
           id="MerTextInput"
@@ -64,8 +65,10 @@ export const Signup = () => {
           Signup
         </button>
         {userID ? (
-          <p>Use "{userID}" as UserID for login<br></br>
-          You have successfully registered!</p>
+          <p>
+            Use "{userID}" as UserID for login<br></br>
+            You have successfully registered!
+          </p>
         ) : null}
       </div>
     </div>

--- a/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
+++ b/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
@@ -30,7 +30,7 @@ export const Signup = () => {
       .then((user) => {
         toast.success("New account is created!");
         console.log("POST success:", user.id);
-        setCookie("userID", user.id);
+        setCookie("userID", user.id, { "path": "/" });
         setUserID(user.id);
         navigate("/");
       })

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 import { MerComponent } from "../MerComponent";
 import { ItemList } from "../ItemList";
 import { fetcher } from "../../helper";
-import { Button, Icon, Form } from "react-bulma-components";
+import { Container, Button, Icon, Form } from "react-bulma-components";
 import { FaYenSign } from "react-icons/fa";
 
 interface Item {
@@ -83,27 +83,33 @@ export const UserProfile: React.FC = () => {
 
   return (
     <MerComponent>
-      <Form.Field>
-        <Form.Label>Balance: {balance}</Form.Label>
-        <Form.Control>
-          <Form.Input
-            type="number"
-            name="balance"
-            placeholder="0"
-            min="0"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setAddedBalance(Number(e.target.value));
-            }}
-            required
-          />
-          <Icon align="left" size="small">
-            <FaYenSign style={{ verticalAlign: -2 }} />
-          </Icon>
-        </Form.Control>
-        <Button onClick={onBalanceSubmit} id="MerButton">
-          Add balance
-        </Button>
-      </Form.Field>
+      <Container className="p-2">
+        <div className="columns is-centered">
+          <div className="column is-5">
+            <Form.Field>
+              <Form.Label>Balance: {balance}</Form.Label>
+              <Form.Control>
+                <Form.Input
+                  type="number"
+                  name="balance"
+                  placeholder="0"
+                  min="0"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    setAddedBalance(Number(e.target.value));
+                  }}
+                  required
+                />
+                <Icon align="left" size="small">
+                  <FaYenSign style={{ verticalAlign: -2 }} />
+                </Icon>
+              </Form.Control>
+              <Button onClick={onBalanceSubmit} id="MerButton">
+                Add balance
+              </Button>
+            </Form.Field>
+          </div>
+        </div>
+      </Container>
 
       <ItemList items={items} items_sold={[]} />
     </MerComponent>

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -27,7 +27,7 @@ export const UserProfile: React.FC = () => {
   const params = useParams();
 
   const fetchItems = () => {
-    fetcher<Item[]>(`/users/${params.id}/items_all`, {
+    fetcher<Item[]>(`/users/${params.id}/items`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -86,33 +86,31 @@ export const UserProfile: React.FC = () => {
 
   return (
     <MerComponent>
-      <Container className="p-2">
-        <div className="columns is-centered">
-          <div className="column is-5">
-            <Form.Field>
-              <Form.Label>Balance: {balance}</Form.Label>
-              <Form.Control>
-                <Form.Input
-                  type="number"
-                  name="balance"
-                  placeholder="0"
-                  min="0"
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setAddedBalance(Number(e.target.value));
-                  }}
-                  required
-                />
-                <Icon align="left" size="small">
-                  <FaYenSign style={{ verticalAlign: -2 }} />
-                </Icon>
-              </Form.Control>
-              <Button onClick={onBalanceSubmit} id="MerButton">
-                Add balance
-              </Button>
-            </Form.Field>
-          </div>
+      <div className="columns is-centered">
+        <div className="column is-4">
+          <Form.Field>
+            <Form.Label>Balance: {balance}</Form.Label>
+            <Form.Control>
+              <Form.Input
+                type="number"
+                name="balance"
+                placeholder="0"
+                min="0"
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setAddedBalance(Number(e.target.value));
+                }}
+                required
+              />
+              <Icon align="left" size="small">
+                <FaYenSign style={{ verticalAlign: -2 }} />
+              </Icon>
+            </Form.Control>
+            <Button onClick={onBalanceSubmit} id="MerButton">
+              Add balance
+            </Button>
+          </Form.Field>
         </div>
-      </Container>
+      </div>
 
       <ItemList items={items} />
     </MerComponent>

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -11,6 +11,7 @@ interface Item {
   name: string;
   price: number;
   category_name: string;
+  status: number;
 }
 
 export const UserProfile: React.FC = () => {

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -91,7 +91,7 @@ export const UserProfile: React.FC = () => {
               name="balance"
               id="MerTextInput"
               placeholder="0"
-              min = "0"
+              min="0"
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setAddedBalance(Number(e.target.value));
               }}
@@ -104,7 +104,7 @@ export const UserProfile: React.FC = () => {
 
           <div>
             <h2>Item List</h2>
-            {<ItemList items={items} />}
+            {<ItemList items={items} items_sold={[]} />}
           </div>
         </div>
       </div>

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { useCookies } from "react-cookie";
 import { useParams } from "react-router-dom";
-import { MerComponent } from "../MerComponent";
 import { toast } from "react-toastify";
 import { ItemList } from "../ItemList";
 import { fetcher } from "../../helper";
+import { Container, Button, Icon, Form } from "react-bulma-components";
+import { FaYenSign } from "react-icons/fa";
 
 interface Item {
   id: number;
@@ -80,35 +81,31 @@ export const UserProfile: React.FC = () => {
   };
 
   return (
-    <MerComponent>
-      <div className="UserProfile">
-        <div>
-          <div>
-            <h2>
-              <span>Balance: {balance}</span>
-            </h2>
-            <input
-              type="number"
-              name="balance"
-              id="MerTextInput"
-              placeholder="0"
-              min="0"
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                setAddedBalance(Number(e.target.value));
-              }}
-              required
-            />
-            <button onClick={onBalanceSubmit} id="MerButton">
-              Add balance
-            </button>
-          </div>
+    <Container>
+      <Form.Field>
+        <Form.Label>Balance: {balance}</Form.Label>
+        <Form.Control>
+          <Form.Input
+            type="number"
+            name="balance"
+            color="success"
+            placeholder="0"
+            min="0"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setAddedBalance(Number(e.target.value));
+            }}
+            required
+          />
+          <Icon align="left" size="small">
+            <FaYenSign style={{ verticalAlign: -2 }} />
+          </Icon>
+        </Form.Control>
+        <Button onClick={onBalanceSubmit} id="MerButton">
+          Add balance
+        </Button>
+      </Form.Field>
 
-          <div>
-            <h2>Item List</h2>
-            {<ItemList items={items} items_sold={[]} />}
-          </div>
-        </div>
-      </div>
-    </MerComponent>
+      <ItemList items={items} items_sold={[]} />
+    </Container>
   );
 };

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 import { MerComponent } from "../MerComponent";
 import { ItemList } from "../ItemList";
 import { fetcher } from "../../helper";
-import { Container, Button, Icon, Form } from "react-bulma-components";
+import { Button, Icon, Form } from "react-bulma-components";
 import { FaYenSign } from "react-icons/fa";
 
 interface Item {
@@ -82,32 +82,30 @@ export const UserProfile: React.FC = () => {
   };
 
   return (
-    <Container>
-      <MerComponent>
-        <Form.Field>
-          <Form.Label>Balance: {balance}</Form.Label>
-          <Form.Control>
-            <Form.Input
-              type="number"
-              name="balance"
-              placeholder="0"
-              min="0"
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                setAddedBalance(Number(e.target.value));
-              }}
-              required
-            />
-            <Icon align="left" size="small">
-              <FaYenSign style={{ verticalAlign: -2 }} />
-            </Icon>
-          </Form.Control>
-          <Button onClick={onBalanceSubmit} id="MerButton">
-            Add balance
-          </Button>
-        </Form.Field>
+    <MerComponent>
+      <Form.Field>
+        <Form.Label>Balance: {balance}</Form.Label>
+        <Form.Control>
+          <Form.Input
+            type="number"
+            name="balance"
+            placeholder="0"
+            min="0"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setAddedBalance(Number(e.target.value));
+            }}
+            required
+          />
+          <Icon align="left" size="small">
+            <FaYenSign style={{ verticalAlign: -2 }} />
+          </Icon>
+        </Form.Control>
+        <Button onClick={onBalanceSubmit} id="MerButton">
+          Add balance
+        </Button>
+      </Form.Field>
 
-        <ItemList items={items} items_sold={[]} />
-      </MerComponent>
-    </Container>
+      <ItemList items={items} items_sold={[]} />
+    </MerComponent>
   );
 };

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -88,7 +88,6 @@ export const UserProfile: React.FC = () => {
           <Form.Input
             type="number"
             name="balance"
-            color="success"
             placeholder="0"
             min="0"
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -27,7 +27,7 @@ export const UserProfile: React.FC = () => {
   const params = useParams();
 
   const fetchItems = () => {
-    fetcher<Item[]>(`/users/${params.id}/items`, {
+    fetcher<Item[]>(`/users/${params.id}/items_all`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -114,7 +114,7 @@ export const UserProfile: React.FC = () => {
         </div>
       </Container>
 
-      <ItemList items={items} items_sold={[]} />
+      <ItemList items={items} />
     </MerComponent>
   );
 };

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useCookies } from "react-cookie";
 import { useParams } from "react-router-dom";
 import { toast } from "react-toastify";
+import { MerComponent } from "../MerComponent";
 import { ItemList } from "../ItemList";
 import { fetcher } from "../../helper";
 import { Container, Button, Icon, Form } from "react-bulma-components";
@@ -82,29 +83,31 @@ export const UserProfile: React.FC = () => {
 
   return (
     <Container>
-      <Form.Field>
-        <Form.Label>Balance: {balance}</Form.Label>
-        <Form.Control>
-          <Form.Input
-            type="number"
-            name="balance"
-            placeholder="0"
-            min="0"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setAddedBalance(Number(e.target.value));
-            }}
-            required
-          />
-          <Icon align="left" size="small">
-            <FaYenSign style={{ verticalAlign: -2 }} />
-          </Icon>
-        </Form.Control>
-        <Button onClick={onBalanceSubmit} id="MerButton">
-          Add balance
-        </Button>
-      </Form.Field>
+      <MerComponent>
+        <Form.Field>
+          <Form.Label>Balance: {balance}</Form.Label>
+          <Form.Control>
+            <Form.Input
+              type="number"
+              name="balance"
+              placeholder="0"
+              min="0"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setAddedBalance(Number(e.target.value));
+              }}
+              required
+            />
+            <Icon align="left" size="small">
+              <FaYenSign style={{ verticalAlign: -2 }} />
+            </Icon>
+          </Form.Control>
+          <Button onClick={onBalanceSubmit} id="MerButton">
+            Add balance
+          </Button>
+        </Form.Field>
 
-      <ItemList items={items} items_sold={[]} />
+        <ItemList items={items} items_sold={[]} />
+      </MerComponent>
     </Container>
   );
 };


### PR DESCRIPTION
## What
- 売り切れた商品もHomeに表示するようにしました。売り切れたものは画像を薄く、説明を灰色にしてあります。
- Login/SignUpでタブが表示されないようにしました。
- items_soldエンドポイントではなく、items_allエンドポイントに変更しました。statusがonSaleとsoldOutのものをすべてとってくるようにしました。
- Homeを下のように商品が並ぶように変更しました。幅がひろいときは3列、せまいときは1列で並びます。
<img width="954" alt="image" src="https://github.com/kotapiku/mercari-build-hackathon-2023/assets/25437132/5226b30b-07bf-4019-85c9-7164a73800f8">

## 変更箇所
- [x] frontend
- [x] backend
