### PR TITLE
詳細をchatGPTで生成するボタンの実装

### DIFF
--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -420,6 +420,11 @@ func (h *Handler) GetUserItems(c echo.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
+func (h *Handler) CreateDescription(c echo.Context) error {
+	// TODO
+	return c.JSON(http.StatusOK, "successful")
+}
+
 func (h *Handler) GetCategories(c echo.Context) error {
 	ctx := c.Request().Context()
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -89,6 +89,7 @@ func run(ctx context.Context) int {
 	e.POST("/register", h.Register)
 	e.POST("/login", h.Login)
 	e.POST("/login_name", h.LoginByName)
+	e.POST("/description", h.CreateDescription)
 
 	e.GET("/search", h.Search)
 

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -54,6 +54,7 @@ export const Header: React.FC = () => {
           <Tabs.Tab
             active={activeTab === tab.name}
             onClick={() => handleTabClick(tab.name, tab.to)}
+            key={tab.name}
           >
             <div className="tabItem">
               {tab.icon}

--- a/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
+++ b/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
@@ -3,6 +3,7 @@ import { useCookies } from "react-cookie";
 import { MerComponent } from "../MerComponent";
 import { toast } from "react-toastify";
 import { fetcher } from "../../helper";
+import { Button, Form } from "react-bulma-components";
 
 interface Category {
   id: number;
@@ -110,66 +111,115 @@ export const Listing: React.FC = () => {
       });
   };
 
+  const createDescription = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+
+    fetcher<string>(`/description`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: values.name,
+        description: values.description,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    })
+      .then((res) => {
+        console.log(res);
+        setValues({ ...values, description: res });
+      })
+      .catch((error: Error) => {
+        toast.error(error.message);
+        console.error("POST error:", error);
+      });
+  };
+
   useEffect(() => {
     fetchCategories();
   }, []);
 
   return (
     <MerComponent>
-      <div className="Listing">
-        <form onSubmit={onSubmit} className="ListingForm">
-          <div>
-            <input
-              type="text"
-              name="name"
-              id="MerTextInput"
-              placeholder="name"
-              onChange={onValueChange}
-              required
-            />
-            <select
-              name="category_id"
-              id="MerTextInput"
-              value={values.category_id}
-              onChange={onSelectChange}
-            >
-              {categories &&
-                categories.map((category) => {
-                  return (
-                    <option value={category.id} key={category.id}>
-                      {category.name}
-                    </option>
-                  );
-                })}
-            </select>
-            <input
-              type="number"
-              name="price"
-              id="MerTextInput"
-              placeholder="price"
-              onChange={onValueChange}
-              required
-            />
-            <input
-              type="text"
-              name="description"
-              id="MerTextInput"
-              placeholder="description"
-              onChange={onValueChange}
-              required
-            />
-            <input
-              type="file"
-              name="image"
-              id="MerTextInput"
-              onChange={onFileChange}
-              required
-            />
-            <button type="submit" id="MerButton">
+      <div className="columns is-centered">
+        <div className="column is-4">
+          <form onSubmit={onSubmit}>
+            <Form.Field>
+              <Form.Label>Item name</Form.Label>
+              <Form.Control>
+                <Form.Input
+                  type="text"
+                  name="name"
+                  id="MerTextInput"
+                  placeholder="name"
+                  value={values.name}
+                  onChange={onValueChange}
+                  required
+                />
+              </Form.Control>
+            </Form.Field>
+            <Form.Field>
+              <Form.Control>
+                <Form.Label>Category</Form.Label>
+                <Form.Select
+                  name="category_id"
+                  value={values.category_id}
+                  onChange={onSelectChange}
+                >
+                  {categories &&
+                    categories.map((category) => {
+                      return (
+                        <option value={category.id} key={category.id}>
+                          {category.name}
+                        </option>
+                      );
+                    })}
+                </Form.Select>
+              </Form.Control>
+            </Form.Field>
+            <Form.Field>
+              <Form.Control>
+                <Form.Label>Price</Form.Label>
+                <Form.Input
+                  type="number"
+                  name="price"
+                  value={values.price}
+                  min="0"
+                  onChange={onValueChange}
+                  required
+                />
+              </Form.Control>
+            </Form.Field>
+            <Form.Field>
+              <Form.Control>
+                <Form.Label>Description</Form.Label>
+                <Form.Input
+                  type="text"
+                  name="description"
+                  value={values.description}
+                  placeholder="description"
+                  onChange={onValueChange}
+                  required
+                />
+                <Button onClick={createDescription}>Create by ChatGPT</Button>
+              </Form.Control>
+            </Form.Field>
+            <Form.Field>
+              <Form.Control>
+                <Form.Label>Image file</Form.Label>
+                <Form.Input
+                  type="file"
+                  name="image"
+                  onChange={onFileChange}
+                  required
+                />
+              </Form.Control>
+            </Form.Field>
+            <Button type="submit" id="MerButton">
               List this item
-            </button>
-          </div>
-        </form>
+            </Button>
+          </form>
+        </div>
       </div>
     </MerComponent>
   );

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 import { MerComponent } from "../MerComponent";
 import { ItemList } from "../ItemList";
 import { fetcher } from "../../helper";
-import { Container, Button, Icon, Form } from "react-bulma-components";
+import { Button, Icon, Form } from "react-bulma-components";
 import { FaYenSign } from "react-icons/fa";
 
 interface Item {


### PR DESCRIPTION
## What
- 詳細を生成するボタンを下のようにつくりました。このボタンを押すと、生成されたもので自動的に書き換えられるようになっています。
<img width="515" alt="image" src="https://github.com/kotapiku/mercari-build-hackathon-2023/assets/25437132/eab407a7-958c-4580-a9d0-6176e82c3c67">

- #24 をマージしたあとにこちらもマージしたいです。今はとりあえず仮のPOST /descriptionエンドポイントを実装してあります。(createDescription関数)
- descriptionエンドポイントはPOSTにしました。

## 変更箇所
- [x] frontend
- [x] backend
